### PR TITLE
Configure project for Render deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+config/
+.env
+

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,11 @@
+services:
+  - type: web
+    name: working-players
+    env: node
+    buildCommand: "npm install"
+    startCommand: "npm start"
+    plan: free
+    autoDeploy: true
+    envVars:
+      - key: FIREBASE_SERVICE_ACCOUNT
+        sync: false

--- a/server.js
+++ b/server.js
@@ -6,7 +6,13 @@ const cors = require('cors');
 const cron = require('node-cron');
 
 const app = express(); // ✅ Initialize Express
-const serviceAccount = require('./config/firebase-service-account.json');
+
+let serviceAccount;
+if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+  serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+} else {
+  serviceAccount = require('./config/firebase-service-account.json');
+}
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),


### PR DESCRIPTION
## Summary
- Load Firebase service account from `FIREBASE_SERVICE_ACCOUNT` environment variable
- Ignore local development artifacts and secrets
- Add Render deployment configuration file

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68a53c9b96fc832e907cd0190c6ec6d1