### PR TITLE
chore: add firebase dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "firebase-admin": "^12.0.0",
+    "node-cron": "^3.0.3",
+    "node-fetch": "^3.3.2"
   },
   "engines": {
     "node": ">=16"

--- a/render.yaml
+++ b/render.yaml
@@ -9,3 +9,5 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 18
+      - key: FIREBASE_SERVICE_ACCOUNT
+        sync: false

--- a/server.js
+++ b/server.js
@@ -6,7 +6,10 @@ const cors = require('cors');
 const cron = require('node-cron');
 
 const app = express(); // ✅ Initialize Express
-const serviceAccount = require('./config/firebase-service-account.json');
+const serviceAccount = JSON.parse(
+  process.env.FIREBASE_SERVICE_ACCOUNT || process.env.firebase_service_account
+);
+serviceAccount.private_key = serviceAccount.private_key.replace(/\\n/g, '\n');
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),


### PR DESCRIPTION
## Summary
- add firebase-admin, node-cron, and node-fetch dependencies
- load Firebase Admin credentials from a single FIREBASE_SERVICE_ACCOUNT environment variable
- document FIREBASE_SERVICE_ACCOUNT in Render configuration

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a58aed0b48832e83415772ac6b463b